### PR TITLE
recent quarter data mismatch issue

### DIFF
--- a/app/scripts/controllers/reports.js
+++ b/app/scripts/controllers/reports.js
@@ -1175,7 +1175,7 @@
                          else{
                              reportRequest.toDate = new Date($scope.dt1.getFullYear(),8,30);
                          }
-                         reportRequest.toDate = new Date($scope.dt1.getFullYear(),8,30);
+                         // reportRequest.toDate = new Date($scope.dt1.getFullYear(),8,30);
                          }
                          if($scope.quarterDisplayType == 'Q4 (Oct to Dec)'){
                          reportRequest.fromDate = new Date($scope.dt1.getFullYear(),9,1);


### PR DESCRIPTION
Issue: when we select a recent quarter for reports generation, Data is reflecting till the end of the quarter,
Ideally, it should reflect till the end of the completed month only.

eg: if we select 2020 and quarter Q3 for mobile academy performance report
Actual: its showing data from 1st July to 30th Sep
Ideal: it should show data from 1st July to 31st Aug

Status: Fixed